### PR TITLE
fix init warning

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -164,7 +164,7 @@ export default function install (Vue, options) {
           }
 
           currentIndex[id] = index
-          if (typeof currentIndex !== 'undefined') {
+          if (typeof currentIndex !== 'undefined' && Object.keys(activableElements).length > 0) {
             idActiveElement = activableElements[id][currentIndex[id]]
             activeElement[id] = idActiveElement
 


### PR DESCRIPTION
![warning](https://user-images.githubusercontent.com/15841535/38264882-f02bd3ca-37a6-11e8-8304-cab3ee353946.jpg)
in some situation, this statement will cause error, because activableElements was empty when initial, but i have no solution to fix it, so i make this statement more strict.