### PR TITLE
fix active class missing

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -192,6 +192,7 @@ export default function install (Vue, options) {
       }
 
       scrollSpyElements[id] = el
+      delete currentIndex[id]
     },
     inserted: function (el) {
       initScrollSections(el)


### PR DESCRIPTION
Switch two compoments with vue-router,each of them has a vue2-scrollspy,then the default active class will missing when `data-scroll-spy-id` is same on each element where a directive is declared.