### PR TITLE
feat: Add option to specify when the menu active class is triggered

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,13 +73,15 @@ section index.
 2. `v-scroll-spy="{allowNoActive: true}"`: allow no active sections when scroll position is outside of the scrollspy 
 container. Default behavior is too keep active at least one section in any case.
 
-3. `v-scroll-spy="{offset: 50}"`: add an offset for scroll and active events.
+3. `v-scroll-spy="{offset: 50}"`: add an offset for scroll events.
 
-4. `v-scroll-spy="{time: 200, steps: 30}"`: set the animation options.
+4. `v-scroll-spy="{menuTriggerOffset: 50}"`: offset to trigger the menu active class (defaults to offset if not provided).
 
-5. `$scrollTo(index: int)` is provided on scope Vue instance to invoke a scroll to the given section index.
+5. `v-scroll-spy="{time: 200, steps: 30}"`: set the animation options.
 
-6. `v-section-selector`: set section which should scrollto
+6. `$scrollTo(index: int)` is provided on scope Vue instance to invoke a scroll to the given section index.
+
+7. `v-section-selector`: set section which should scrollto
 
 ### **v-scroll-spy-active**
 

--- a/src/index.js
+++ b/src/index.js
@@ -35,11 +35,19 @@ const install = (Vue, options) => {
   const activableElements = {}
   const currentIndex = {}
 
+  //  set menuTriggerOffset based on offset (for backwards compatibility)
+  const menuTriggerOffset = options
+    && typeof options === 'object'
+    && 'offset' in options
+      ? options.offset
+      : 0;
+
   options = Object.assign({
     allowNoActive: false,
     sectionSelector: null,
     data: null,
     offset: 0,
+    menuTriggerOffset: menuTriggerOffset,
     time: 500,
     steps: 30,
     easing: null,
@@ -153,7 +161,7 @@ const install = (Vue, options) => {
           index = idScrollSections.length
         } else {
           for (index = 0; index < idScrollSections.length; index++) {
-            if (getOffsetTop(idScrollSections[index], scrollEl) - options.offset > scrollEl.scrollTop) {
+            if (getOffsetTop(idScrollSections[index], scrollEl) - options.menuTriggerOffset > scrollEl.scrollTop) {
               break
             }
           }


### PR DESCRIPTION
menuTriggerOffset was added to the options. This option allows for users to specify when the menu active class gets set separate from the `offset` option.

If this option is not provided, it falls back to the offset property.